### PR TITLE
Add auth interceptor and favorite feedback

### DIFF
--- a/frontend/components/CallCard.tsx
+++ b/frontend/components/CallCard.tsx
@@ -3,9 +3,10 @@ import { Box, Heading, Text, Badge, Button, Stack } from '@chakra-ui/react';
 interface Props {
   call: any;
   onFavorite?: (id: number) => void;
+  canFavorite?: boolean;
 }
 
-const CallCard = ({ call, onFavorite }: Props) => (
+const CallCard = ({ call, onFavorite, canFavorite = true }: Props) => (
   <Box borderWidth="1px" borderRadius="lg" p={4} mb={4}>
     <Stack direction="row" justify="space-between" align="start">
       <Heading size="md">{call.title}</Heading>
@@ -20,7 +21,11 @@ const CallCard = ({ call, onFavorite }: Props) => (
     </Stack>
     <Stack direction="row" spacing={2} mt={4}>
       <Button as="a" href={call.source_url} target="_blank" rel="noopener noreferrer">Ver fuente</Button>
-      {onFavorite && <Button onClick={() => onFavorite(call.id)}>Favorito</Button>}
+      {onFavorite && (
+        <Button onClick={() => onFavorite(call.id)} isDisabled={!canFavorite}>
+          Favorito
+        </Button>
+      )}
     </Stack>
   </Box>
 );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -4,4 +4,28 @@ const api = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
 });
 
+api.interceptors.request.use((config) => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers = {
+        ...config.headers,
+        Authorization: `Bearer ${token}`
+      };
+    }
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (typeof window !== 'undefined' && error.response?.status === 401) {
+      localStorage.removeItem('token');
+      window.dispatchEvent(new Event('auth:logout'));
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default api;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Heading, SimpleGrid, Select, Stack, Spinner, useToast } from '@chakra-ui/react';
+import axios from 'axios';
 import api from '../lib/api';
 import CallCard from '../components/CallCard';
 
@@ -7,6 +8,7 @@ const HomePage = () => {
   const [calls, setCalls] = useState<any[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [country, setCountry] = useState<string>('');
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
   const toast = useToast();
 
   const fetchCalls = async (filters: any = {}) => {
@@ -23,10 +25,39 @@ const HomePage = () => {
 
   useEffect(() => {
     fetchCalls();
+    if (typeof window !== 'undefined') {
+      const updateAuthState = () => {
+        const token = localStorage.getItem('token');
+        setIsAuthenticated(!!token);
+      };
+
+      updateAuthState();
+      window.addEventListener('auth:logout', updateAuthState);
+      window.addEventListener('storage', updateAuthState);
+
+      return () => {
+        window.removeEventListener('auth:logout', updateAuthState);
+        window.removeEventListener('storage', updateAuthState);
+      };
+    }
   }, []);
 
   const handleFavorite = async (id: number) => {
-    toast({ title: 'Favoritos requieren login', status: 'info' });
+    if (!isAuthenticated) {
+      toast({ title: 'Inicia sesión para guardar favoritos', status: 'info' });
+      return;
+    }
+
+    try {
+      await api.post(`/convocatorias/${id}/favorite`);
+      toast({ title: 'Convocatoria agregada a favoritos', status: 'success' });
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        toast({ title: 'Tu sesión ha expirado, vuelve a iniciar sesión', status: 'warning' });
+      } else {
+        toast({ title: 'No se pudo agregar a favoritos', status: 'error' });
+      }
+    }
   };
 
   return (
@@ -43,7 +74,12 @@ const HomePage = () => {
       {loading ? <Spinner /> : (
         <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
           {calls.map((call) => (
-            <CallCard key={call.id} call={call} onFavorite={handleFavorite} />
+            <CallCard
+              key={call.id}
+              call={call}
+              onFavorite={handleFavorite}
+              canFavorite={isAuthenticated}
+            />
           ))}
         </SimpleGrid>
       )}


### PR DESCRIPTION
## Summary
- add Axios interceptors to automatically send bearer tokens and clear them on 401s
- disable favorite actions when unauthenticated and surface detailed toasts for favorite attempts
- update favorite button handling to call the protected endpoint and react to auth failures

## Testing
- npm --prefix frontend run lint *(fails: missing TypeScript type packages in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a53c85cc8327b2058c69ef6f5a7f