### PR TITLE
Add registration page with navigation from login

### DIFF
--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Heading, Stack, Input, Button, useToast } from '@chakra-ui/react';
+import { Heading, Stack, Input, Button, useToast, Text, Link as ChakraLink } from '@chakra-ui/react';
+import NextLink from 'next/link';
 import api from '../lib/api';
 
 const LoginPage = () => {
@@ -26,6 +27,12 @@ const LoginPage = () => {
       <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
       <Input placeholder="Contraseña" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
       <Button onClick={handleLogin}>Ingresar</Button>
+      <Text textAlign="center">
+        ¿No tienes cuenta?{' '}
+        <ChakraLink as={NextLink} href="/register" color="teal.500">
+          Regístrate
+        </ChakraLink>
+      </Text>
     </Stack>
   );
 };

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import {
+  Heading,
+  Stack,
+  Input,
+  Button,
+  useToast,
+  Text,
+  Link as ChakraLink
+} from '@chakra-ui/react';
+import NextLink from 'next/link';
+import api from '../lib/api';
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const RegisterPage = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const toast = useToast();
+  const router = useRouter();
+
+  const handleRegister = async () => {
+    if (!email || !password) {
+      toast({ title: 'Por favor completa todos los campos.', status: 'warning' });
+      return;
+    }
+
+    if (!emailRegex.test(email)) {
+      toast({ title: 'Ingresa un email válido.', status: 'warning' });
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await api.post('/auth/register', { email, password });
+      toast({ title: 'Registro exitoso. Inicia sesión para continuar.', status: 'success' });
+      router.push('/login');
+    } catch (error) {
+      toast({ title: 'Error al registrarse. Intenta nuevamente.', status: 'error' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Stack spacing={4}>
+      <Heading>Crear cuenta</Heading>
+      <Input
+        placeholder="Email"
+        value={email}
+        type="email"
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <Input
+        placeholder="Contraseña"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <Button onClick={handleRegister} isLoading={isSubmitting}>
+        Registrarse
+      </Button>
+      <Text textAlign="center">
+        ¿Ya tienes una cuenta?{' '}
+        <ChakraLink as={NextLink} href="/login" color="teal.500">
+          Inicia sesión
+        </ChakraLink>
+      </Text>
+    </Stack>
+  );
+};
+
+export default RegisterPage;


### PR DESCRIPTION
## Summary
- add a registration page with email and password validation and API call
- redirect to the login page after successful registration and show helpful toasts
- link from the login page to the registration flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a53f3fe08327a9430a227d8729cd