### PR TITLE
Add admin scrape log endpoint and UI

### DIFF
--- a/backend/app/api/scrape_logs.py
+++ b/backend/app/api/scrape_logs.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+from ..services import crud
+from .deps import get_admin_user_dep, get_db_dep
+
+router = APIRouter(prefix="/scrape-logs", tags=["scrape-logs"])
+
+
+@router.get("", response_model=list[schemas.SourceScrapeLog])
+def get_latest_scrape_logs(
+    db: Session = Depends(get_db_dep),
+    _: models.User = Depends(get_admin_user_dep),
+):
+    return crud.get_latest_scrape_logs(db)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
 from fastapi import APIRouter
 
 from .core.config import get_settings
-from .api import auth, calls, alerts, sources, metrics
+from .api import auth, calls, alerts, sources, metrics, scrape_logs
 from .core.rate_limiter import rate_limit
 
 settings = get_settings()
@@ -55,6 +55,7 @@ api_router.include_router(calls.router)
 api_router.include_router(alerts.router)
 api_router.include_router(sources.router)
 api_router.include_router(metrics.router)
+api_router.include_router(scrape_logs.router)
 
 app.include_router(api_router)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -125,6 +125,11 @@ class ScrapeLogRead(ORMModel):
     error_message: Optional[str]
 
 
+class SourceScrapeLog(BaseModel):
+    source: SourceRead
+    log: Optional[ScrapeLogRead] = None
+
+
 class MetricsResponse(BaseModel):
     scrapes_success: int
     scrapes_failed: int

--- a/frontend/pages/admin.tsx
+++ b/frontend/pages/admin.tsx
@@ -2,25 +2,64 @@ import { useEffect, useState } from 'react';
 import { Heading, Table, Thead, Tbody, Tr, Th, Td, Spinner, Stack, useToast } from '@chakra-ui/react';
 import api from '../lib/api';
 
+interface Source {
+  id: number;
+  name: string;
+  access_method: string;
+  frequency_hours: number;
+  robots_status: string;
+}
+
+interface ScrapeLog {
+  id: number;
+  started_at: string;
+  finished_at?: string;
+  status: string;
+  items_fetched: number;
+  items_created: number;
+  items_updated: number;
+  error_message?: string;
+}
+
+interface SourceScrapeLog {
+  source: Source;
+  log: ScrapeLog | null;
+}
+
 const AdminPage = () => {
-  const [sources, setSources] = useState<any[]>([]);
+  const [scrapeLogs, setScrapeLogs] = useState<SourceScrapeLog[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const toast = useToast();
 
-  const fetchSources = async () => {
+  const fetchScrapeLogs = async () => {
     setLoading(true);
     try {
-      const response = await api.get('/sources');
-      setSources(response.data);
+      const response = await api.get('/scrape-logs');
+      setScrapeLogs(response.data);
     } catch (error) {
-      toast({ title: 'Error cargando fuentes', status: 'error' });
+      toast({ title: 'Error cargando registros', status: 'error' });
     } finally {
       setLoading(false);
     }
   };
 
+  const formatDate = (dateString?: string) => {
+    if (!dateString) {
+      return '—';
+    }
+    const date = new Date(dateString);
+    return date.toLocaleString();
+  };
+
+  const formatItems = (log?: ScrapeLog | null) => {
+    if (!log) {
+      return '—';
+    }
+    return `${log.items_fetched}/${log.items_created}/${log.items_updated}`;
+  };
+
   useEffect(() => {
-    fetchSources();
+    fetchScrapeLogs();
   }, []);
 
   return (
@@ -34,15 +73,21 @@ const AdminPage = () => {
               <Th>Método</Th>
               <Th>Frecuencia (h)</Th>
               <Th>robots.txt</Th>
+              <Th>Última ejecución</Th>
+              <Th>Items (F/C/U)</Th>
+              <Th>Error</Th>
             </Tr>
           </Thead>
           <Tbody>
-            {sources.map((source) => (
+            {scrapeLogs.map(({ source, log }) => (
               <Tr key={source.id}>
                 <Td>{source.name}</Td>
                 <Td>{source.access_method}</Td>
                 <Td>{source.frequency_hours}</Td>
                 <Td>{source.robots_status}</Td>
+                <Td>{log ? formatDate(log.finished_at || log.started_at) : 'Sin registros'}</Td>
+                <Td>{formatItems(log)}</Td>
+                <Td>{log?.error_message || '—'}</Td>
               </Tr>
             ))}
           </Tbody>


### PR DESCRIPTION
## Summary
- add an authenticated `/scrape-logs` endpoint that returns the latest log for each source
- expose supporting schema/CRUD logic and register the router with the FastAPI app
- update the admin dashboard to consume the new endpoint and show last run, items, and errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6a540c7c48327b8ee42567f41fd48