### PR TITLE
Use Playwright base image for backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,12 +1,16 @@
-FROM python:3.11-slim
+FROM mcr.microsoft.com/playwright/python:v1.41.1-jammy
 
 WORKDIR /app
 
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt && playwright install-deps && playwright install chromium
+# Cliente de Postgres para facilitar carga de schema/diagnóstico
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends postgresql-client \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-ENV PYTHONPATH=/app
-
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Ejecuta FastAPI con host público
+CMD ["uvicorn","app.main:app","--host","0.0.0.0","--port","8000"]


### PR DESCRIPTION
## Summary
- replace the backend Dockerfile with the Playwright Python Jammy base image to avoid install-deps failures
- install the PostgreSQL client package so psql is available for diagnostics and schema loading

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9bdd1d8fc8327adb4b33430919b0b