### PR TITLE
Update frontend Dockerfile to Node 20 Alpine dev setup

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,13 @@
 FROM node:20-alpine
+
 WORKDIR /app
-COPY package.json package-lock.json* yarn.lock* pnpm-lock.yaml* ./
-RUN npm install
+
+# Instala dependencias con caché
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copia el resto del código
 COPY . .
-RUN npm run build
-CMD ["npm", "start"]
+
+# El comando real lo definimos en docker-compose (para forzar 0.0.0.0)
+CMD ["npm","run","dev"]


### PR DESCRIPTION
## Summary
- switch the frontend Dockerfile to a Node 20 Alpine base image
- install dependencies with `npm ci` using a cached layer before copying sources
- set the container command to `npm run dev` so docker-compose can enforce 0.0.0.0 binding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9bde309dc8327b8acc5579617b404