### PR TITLE
docs: add .env.example with correct JSON arrays and URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,14 @@
+# === Backend ===
 DATABASE_URL=postgresql+psycopg2://convoca:convoca@db:5432/convocafinder
-SECRET_KEY=change-me
+REDIS_URL=redis://redis:6379/0
+JWT_SECRET=please_change_me_to_a_long_random_string
+# Importante: listas deben ir como JSON válido
+CORS_ORIGINS=["http://localhost:3000"]
+
+# SMTP local (Mailhog)
 SMTP_HOST=mailhog
 SMTP_PORT=1025
-SMTP_USERNAME=
-SMTP_PASSWORD=
-SMTP_FROM_EMAIL=convocafinder@example.com
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_CHANNEL_ID=
-REDIS_URL=redis://redis:6379/0
-RATE_LIMIT_PER_MINUTE=60
+
+# === Frontend ===
+# En el navegador usa localhost; dentro de Docker se puede usar http://backend:8000
 NEXT_PUBLIC_API_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- update the root .env.example with backend and frontend defaults
- document JSON array formatting for CORS origins

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9be01faf08327a0bf3e3cbd0464de