### PR TITLE
frontend: honor NEXT_PUBLIC_API_URL with safe default

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,7 +1,48 @@
-import axios from 'axios';
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
 
-const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
-});
+const shouldSetJsonContentType = (body: BodyInit | null | undefined) => {
+  if (!body) {
+    return false;
+  }
+  if (typeof body === 'string') {
+    return true;
+  }
+  if (typeof Blob !== 'undefined' && body instanceof Blob) {
+    return false;
+  }
+  if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+    return false;
+  }
+  if (typeof FormData !== 'undefined' && body instanceof FormData) {
+    return false;
+  }
+  if (typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) {
+    return false;
+  }
+  return true;
+};
 
-export default api;
+export const apiFetch = async <T = any>(path: string, init: RequestInit = {}): Promise<T> => {
+  const headers = new Headers(init.headers ?? {});
+
+  if (!headers.has('Content-Type') && shouldSetJsonContentType(init.body)) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers
+  });
+
+  if (!response.ok) {
+    const bodyText = await response.text();
+    throw new Error(`API ${response.status} ${response.statusText}: ${bodyText}`);
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (contentType && contentType.includes('application/json')) {
+    return response.json() as Promise<T>;
+  }
+
+  return response.text() as unknown as Promise<T>;
+};

--- a/frontend/pages/admin.tsx
+++ b/frontend/pages/admin.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Heading, Table, Thead, Tbody, Tr, Th, Td, Spinner, Stack, useToast } from '@chakra-ui/react';
-import api from '../lib/api';
+import { apiFetch } from '../lib/api';
 
 const AdminPage = () => {
   const [sources, setSources] = useState<any[]>([]);
@@ -10,8 +10,9 @@ const AdminPage = () => {
   const fetchSources = async () => {
     setLoading(true);
     try {
-      const response = await api.get('/sources');
-      setSources(response.data);
+      const result = await apiFetch<any>('/sources');
+      const items = Array.isArray(result) ? result : result?.data ?? [];
+      setSources(items);
     } catch (error) {
       toast({ title: 'Error cargando fuentes', status: 'error' });
     } finally {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Heading, SimpleGrid, Select, Stack, Spinner, useToast } from '@chakra-ui/react';
-import api from '../lib/api';
+import { apiFetch } from '../lib/api';
 import CallCard from '../components/CallCard';
 
 const HomePage = () => {
@@ -9,11 +9,19 @@ const HomePage = () => {
   const [country, setCountry] = useState<string>('');
   const toast = useToast();
 
-  const fetchCalls = async (filters: any = {}) => {
+  const fetchCalls = async (filters: Record<string, string> = {}) => {
     setLoading(true);
     try {
-      const response = await api.get('/convocatorias', { params: filters });
-      setCalls(response.data.data);
+      const searchParams = new URLSearchParams();
+      Object.entries(filters).forEach(([key, value]) => {
+        if (value) {
+          searchParams.set(key, value);
+        }
+      });
+      const query = searchParams.toString();
+      const result = await apiFetch<any>(`/convocatorias${query ? `?${query}` : ''}`);
+      const items = Array.isArray(result) ? result : result?.data ?? [];
+      setCalls(items);
     } catch (error) {
       toast({ title: 'Error cargando convocatorias', status: 'error' });
     } finally {

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Heading, Stack, Input, Button, useToast } from '@chakra-ui/react';
-import api from '../lib/api';
+import { apiFetch } from '../lib/api';
 
 const LoginPage = () => {
   const [email, setEmail] = useState('');
@@ -12,8 +12,16 @@ const LoginPage = () => {
       const formData = new URLSearchParams();
       formData.append('username', email);
       formData.append('password', password);
-      const response = await api.post('/auth/login', formData);
-      localStorage.setItem('token', response.data.access_token);
+      const data = await apiFetch<{ access_token: string }>('/auth/login', {
+        method: 'POST',
+        body: formData,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        }
+      });
+      if (data?.access_token) {
+        localStorage.setItem('token', data.access_token);
+      }
       toast({ title: 'Inicio de sesión exitoso', status: 'success' });
     } catch (error) {
       toast({ title: 'Error al iniciar sesión', status: 'error' });


### PR DESCRIPTION
## Summary
- replace the axios API client with a fetch helper that respects NEXT_PUBLIC_API_URL and defaults to localhost
- update admin, home, and login pages to consume the new helper and handle varying JSON response shapes

## Testing
- npm run lint *(fails: missing @types/react and @types/node packages as reported by Next.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d9be4ed97c832788c70028e3aff281