### PR TITLE
Disable backend reload in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,8 @@ services:
 
   backend:
     build: ./backend
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    # command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir /app
     volumes:
       - ./backend:/app
     environment:


### PR DESCRIPTION
## Summary
- remove the default `--reload` flag from the backend uvicorn command to avoid connection resets when bind mounts trigger reloads
- document the optional reload command for intensive development scenarios

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9be62d8c883279bc31e891057b34e