### PR TITLE
Align schema.sql with ORM models

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -39,10 +39,11 @@ CREATE TABLE IF NOT EXISTS calls (
     requirements JSONB DEFAULT '[]'::jsonb NOT NULL,
     source_url VARCHAR(500) NOT NULL,
     tags JSONB DEFAULT '[]'::jsonb NOT NULL,
-    last_scraped_at TIMESTAMP WITH TIME ZONE NOT NULL,
-    fingerprint_hash VARCHAR(255) NOT NULL UNIQUE,
+    last_scraped_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    fingerprint_hash VARCHAR(255) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    CONSTRAINT uq_calls_fingerprint UNIQUE (fingerprint_hash)
 );
 
 CREATE TABLE IF NOT EXISTS call_versions (

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,4 @@
+# Backlog
+
+## Migraciones de base de datos
+- [ ] Adoptar Alembic para manejar migraciones y reemplazar el uso manual de `schema.sql`. Documentar la estrategia de migraciones y plan para eliminar `schema.sql` una vez establecidas las migraciones automáticas.


### PR DESCRIPTION
## Summary
- update the calls table definition so schema.sql matches the SQLAlchemy models defaults and constraints
- add a backlog task to adopt Alembic migrations and phase out the manual schema file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9be6b68408327adec40fa72fe5781